### PR TITLE
chore: rename Docker image to oauth-refresh

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: integration-os/google-artifact-registry-action@v2
         with:
-          image: "us-docker.pkg.dev/integrationos/docker-oss/oauth:${{ env.docker_image_tag }}"
+          image: "us-docker.pkg.dev/integrationos/docker-oss/oauth-refresh:${{ env.docker_image_tag }}"
           service_account: github-actions@integrationos.iam.gserviceaccount.com
           workload_identity_provider: projects/356173785332/locations/global/workloadIdentityPools/github-actions/providers/github-actions


### PR DESCRIPTION
With the introduction of the platform-oauth service in https://github.com/integration-os/integrationos/pull/53 we want to rename the Docker image created by this repo to avoid confusion between the two services.